### PR TITLE
mgis.fenics - Remove dimension assert and fix missing time step

### DIFF
--- a/bindings/python/mgis/fenics/gradient_flux.py
+++ b/bindings/python/mgis/fenics/gradient_flux.py
@@ -78,12 +78,12 @@ class Gradient(QuadratureFunction):
         if symmetric is None:
             self.expression = expression
         elif symmetric:
-            if self.variable.geometric_dimension() == 2:
+            if ufl.shape(expression) == (2, 2):
                 self.expression = as_vector([symmetric_tensor_to_vector(expression)[i] for i in range(4)])
             else:
                 self.expression = symmetric_tensor_to_vector(expression)
         else:
-            if self.variable.geometric_dimension() == 2:
+            if ufl.shape(expression) == (2, 2):
                 self.expression = as_vector([nonsymmetric_tensor_to_vector(expression)[i] for i in range(5)])
             else:
                 self.expression = nonsymmetric_tensor_to_vector(expression)

--- a/bindings/python/mgis/fenics/nonlinear_problem.py
+++ b/bindings/python/mgis/fenics/nonlinear_problem.py
@@ -66,9 +66,11 @@ class AbstractNonlinearProblem:
         self._dummy_function = Function(self.W0)
 
         if self.material.hypothesis == mgis_bv.Hypothesis.Tridimensional:
-            assert self.u.geometric_dimension()==3, "Conflicting geometric dimension and material hypothesis"
+            if self.u.geometric_dimension()!=3:
+                warning("Conflicting geometric dimension and material hypothesis")
         else:
-            assert self.u.geometric_dimension()==2, "Conflicting geometric dimension and material hypothesis"
+            if self.u.geometric_dimension()!=2:
+                warning("Conflicting geometric dimension and material hypothesis")
 
         if bcs is None:
             self.bcs = []
@@ -383,7 +385,7 @@ class AbstractNonlinearProblem:
         self.material.update_external_state_variables(self.state_variables["external"])
         # integrate the behaviour
         mgis_bv.integrate(self.material.data_manager, self.integration_type,
-                          0, 0, self.material.data_manager.n);
+                          self.dt, 0, self.material.data_manager.n);
         # getting the stress and consistent tangent operator back to
         # the FEniCS world.
         self.update_fluxes()


### PR DESCRIPTION
* Replace assertion checking that geometric dimension of the unknown field should equal the material hypothesis dimension by a simple warning : this assertion would not make it possible to use a 3D behaviour for a 2D computation with plane stress handled by FEniCS for instance
* Fix a missing time step when calling the behaviour integration