### PR TITLE
Orthotropic behaviours in mgis.fenics

### DIFF
--- a/bindings/python/mgis/fenics/gradient_flux.py
+++ b/bindings/python/mgis/fenics/gradient_flux.py
@@ -77,6 +77,7 @@ class Gradient(QuadratureFunction):
         self.variable = variable
         if symmetric is None:
             self.expression = expression
+        # TODO: treat axisymmetric case
         elif symmetric:
             if ufl.shape(expression) == (2, 2):
                 self.expression = as_vector([symmetric_tensor_to_vector(expression)[i] for i in range(4)])

--- a/bindings/python/mgis/fenics/nonlinear_material.py
+++ b/bindings/python/mgis/fenics/nonlinear_material.py
@@ -108,14 +108,7 @@ class MFrontNonlinearMaterial:
             elif isinstance(value, dolfin.Constant):
                 mgis_bv.setExternalStateVariable(s, key, float(value))
             else:
-                # if isinstance(value, dolfin.Function):
-                #     values = value.vector().get_local()
-                # elif isinstance(value, Var):
-                #     value.update()
                 values = compute_on_quadrature(value, mesh, degree).vector().get_local()
-                # values = value.function.vector().get_local()
-                # else:
-                #     raise NotImplementedError("{} type is not supported for external state variables".format(type(value)))
                 mgis_bv.setExternalStateVariable(s, key, values, mgis_bv.MaterialStateManagerStorageMode.LocalStorage)
 
     def get_parameter(self, name):

--- a/bindings/python/mgis/fenics/nonlinear_material.py
+++ b/bindings/python/mgis/fenics/nonlinear_material.py
@@ -9,6 +9,7 @@ Laboratoire Navier (ENPC,IFSTTAR,CNRS UMR 8205)
 """
 import mgis.behaviour as mgis_bv
 from .gradient_flux import Var
+from .utils import compute_on_quadrature
 import dolfin
 import subprocess
 import os
@@ -24,7 +25,8 @@ class MFrontNonlinearMaterial:
     This class handles the loading of a MFront behaviour through MGIS.
     """
     def __init__(self, path, name, hypothesis="3d",
-                 material_properties={}, parameters={}):
+                 material_properties={}, parameters={},
+                 rotation_matrix=None):
         """
         Parameters
         -----------
@@ -42,12 +44,16 @@ class MFrontNonlinearMaterial:
         parameters : dict
             a dictionary of parameters. The dictionary keys must match the parameter
             names declared in the MFront behaviour. Values must be constants.
+        rotation_matrix : Matrix
+            a 2D or 3D rotation matrix expressing the rotation from the global
+            frame to the material frame
         """
         self.path = path
         self.name = name
         # Defining the modelling hypothesis
         self.hypothesis = mgis_hypothesis[hypothesis]
         self.material_properties = material_properties
+        self.rotation_matrix = rotation_matrix
         # Loading the behaviour
         try:
             self.load_behaviour()
@@ -74,16 +80,16 @@ class MFrontNonlinearMaterial:
         else:
             self.behaviour = mgis_bv.load(self.path, self.name, self.hypothesis)
 
-    def set_data_manager(self, ngauss):
+    def set_data_manager(self, degree, ngauss, mesh):
         # Setting the material data manager
         self.data_manager = mgis_bv.MaterialDataManager(self.behaviour, ngauss)
-        self.update_material_properties()
+        self.update_material_properties(degree, mesh)
 
     def update_parameters(self, parameters):
         for (key, value) in parameters.items():
             self.behaviour.setParameter(key, value)
 
-    def update_material_properties(self, material_properties=None):
+    def update_material_properties(self, degree, mesh, material_properties=None):
         if material_properties is not None:
             self.material_properties = material_properties
         for s in [self.data_manager.s0, self.data_manager.s1]:
@@ -91,11 +97,10 @@ class MFrontNonlinearMaterial:
                 if type(value) in [int, float]:
                     mgis_bv.setMaterialProperty(s, key, value)
                 else:
-                    if isinstance(value, dolfin.Function):
-                        value = value.vector().get_local()
-                    mgis_bv.setMaterialProperty(s, key, value, mgis_bv.MaterialStateManagerStorageMode.LocalStorage)
+                    values = compute_on_quadrature(value, mesh, degree).vector().get_local()
+                    mgis_bv.setMaterialProperty(s, key, values, mgis_bv.MaterialStateManagerStorageMode.LocalStorage)
 
-    def update_external_state_variables(self, external_state_variables):
+    def update_external_state_variables(self, degree, mesh, external_state_variables):
         s = self.data_manager.s1
         for (key, value) in external_state_variables.items():
             if type(value) in [int, float]:
@@ -103,15 +108,14 @@ class MFrontNonlinearMaterial:
             elif isinstance(value, dolfin.Constant):
                 mgis_bv.setExternalStateVariable(s, key, float(value))
             else:
-                if isinstance(value, dolfin.Function):
-                    values = value.vector().get_local()
-                elif isinstance(value, Var):
-                    value.update()
-                    values = value.function.vector().get_local()
-                else:
-                    print(isinstance(value, Var))
-                    print(value)
-                    raise NotImplementedError("{} type is not supported for external state variables".format(type(value)))
+                # if isinstance(value, dolfin.Function):
+                #     values = value.vector().get_local()
+                # elif isinstance(value, Var):
+                #     value.update()
+                values = compute_on_quadrature(value, mesh, degree).vector().get_local()
+                # values = value.function.vector().get_local()
+                # else:
+                #     raise NotImplementedError("{} type is not supported for external state variables".format(type(value)))
                 mgis_bv.setExternalStateVariable(s, key, values, mgis_bv.MaterialStateManagerStorageMode.LocalStorage)
 
     def get_parameter(self, name):

--- a/bindings/python/mgis/fenics/nonlinear_material.py
+++ b/bindings/python/mgis/fenics/nonlinear_material.py
@@ -44,9 +44,10 @@ class MFrontNonlinearMaterial:
         parameters : dict
             a dictionary of parameters. The dictionary keys must match the parameter
             names declared in the MFront behaviour. Values must be constants.
-        rotation_matrix : Matrix
-            a 2D or 3D rotation matrix expressing the rotation from the global
-            frame to the material frame
+        rotation_matrix : Numpy array, list of list, UFL matrix
+            a 3D rotation matrix expressing the rotation from the global
+            frame to the material frame. The matrix can be spatially variable
+            (either UFL matrix or function of Tensor type)
         """
         self.path = path
         self.name = name

--- a/bindings/python/mgis/fenics/nonlinear_problem.py
+++ b/bindings/python/mgis/fenics/nonlinear_problem.py
@@ -336,11 +336,8 @@ class AbstractNonlinearProblem:
             block_shape = self.flattened_block_shapes[i]
             tang_block_vals = self.material.data_manager.K[:,buff:buff+block_shape].ravel()
             if self.material.rotation_matrix is not None:
-                # print("Tang block (before):\n",np.array_str(tang_block_vals[:36].reshape((6, 6)), precision=2))
-                print("Tang block (before):\n", tang_block_vals)
-                self.material.behaviour.rotateTangentOperatorBlocks(tang_block_vals, self.rotation_values)
-                print("Tang block (after):\n", tang_block_vals)
-                # print("Tang block (after):\n",np.array_str(tang_block_vals[:36].reshape((6, 6)), precision=2))
+                mgis_bv.rotateTangentOperatorBlocks(tang_block_vals, self.material.behaviour,
+                                                    self.rotation_values)
             t.vector().set_local(tang_block_vals)
             buff += block_shape
 
@@ -349,10 +346,10 @@ class AbstractNonlinearProblem:
         for (i, f) in enumerate(self.material.get_flux_names()):
             flux = self.fluxes[f]
             block_shape = self.material.get_flux_sizes()[i]
-            flux_vals = self.material.data_manager.s1.thermodynamic_forces[:,buff:buff+block_shape].flatten()
+            flux_vals = self.material.data_manager.s1.thermodynamic_forces[:,buff:buff+block_shape].ravel()
             if self.material.rotation_matrix is not None:
-                self.material.behaviour.rotateThermodynamicForces(flux_vals, self.rotation_values)
-                print("Flux:\n",flux_vals[:12])
+                mgis_bv.rotateThermodynamicForces(flux_vals, self.material.behaviour,
+                                                  self.rotation_values)
             flux.function.vector().set_local(flux_vals)
             buff += block_shape
 
@@ -364,9 +361,8 @@ class AbstractNonlinearProblem:
             block_shape = self.material.get_gradient_sizes()[i]
             grad_vals = gradient.function.vector().get_local()
             if self.material.rotation_matrix is not None:
-                print(grad_vals[:12])
-                self.material.behaviour.rotateGradients(grad_vals, self.rotation_values)
-                print(grad_vals[:12])
+                mgis_bv.rotateGradients(grad_vals, self.material.behaviour,
+                                        self.rotation_values)
             if gradient.shape > 0:
                 grad_vals = grad_vals.reshape((self.material.data_manager.n, gradient.shape))
             else:

--- a/bindings/python/mgis/fenics/nonlinear_problem.py
+++ b/bindings/python/mgis/fenics/nonlinear_problem.py
@@ -206,12 +206,6 @@ class AbstractNonlinearProblem:
             self.state_variables["external"].update({name: Constant(expression)})
         else:
             self.state_variables["external"].update({name: expression})
-        # if isinstance(expression, Constant):
-        #     self.state_variables["external"].update({name: expression})
-        # elif type(expression) == float:
-        #     self.state_variables["external"].update({name: Constant(expression)})
-        # else:
-        #     self.state_variables["external"].update({name: Var(self.u, expression, name)})
 
     def set_loading(self, Fext):
         """

--- a/bindings/python/mgis/fenics/nonlinear_problem.py
+++ b/bindings/python/mgis/fenics/nonlinear_problem.py
@@ -91,9 +91,12 @@ class AbstractNonlinearProblem:
         self.dt = 0
 
         if self.material.rotation_matrix is not None:
-            self.rotation_values = compute_on_quadrature(self.material.rotation_matrix,
-                                                         self.mesh, self.quadrature_degree)
-            self.rotation_values = self.rotation_values.vector().get_local()[:9]
+            if isinstance(self.material.rotation_matrix, (list, tuple, np.ndarray)):
+                self.rotation_values = np.asarray(self.material.rotation_matrix).ravel()
+            else:
+                self.rotation_values = compute_on_quadrature(self.material.rotation_matrix,
+                                                             self.mesh, self.quadrature_degree)
+                self.rotation_values = self.rotation_values.vector().get_local()
 
         self.state_variables =  {"internal": None,
                                  "external": dict.fromkeys(self.material.get_external_state_variable_names(), None)}

--- a/bindings/python/mgis/fenics/utils.py
+++ b/bindings/python/mgis/fenics/utils.py
@@ -119,3 +119,47 @@ def get_quadrature_element(cell, degree, dim=0):
         return TensorElement("Quadrature", cell, degree=degree, shape=dim, quad_scheme='default')
     else:
         raise ValueError("Wrong shape for dim=", dim)
+
+def interpolate_on_quadrature(f, degree):
+    V = f.function_space()
+    Ve = V.ufl_element()
+    if Ve.family()=="Quadrature":
+        return f
+    else:
+        shape = Ve.value_shape()
+        if len(shape) == 1:
+            shape = shape[0]
+        Vge = Ve.__class__("Quadrature", Ve.cell(), degree, shape,
+                           quad_scheme="default")
+        Vg = FunctionSpace(V.mesh(), Vge)
+        fg = Function(Vg)
+        fg.interpolate(f)
+        return fg
+
+def project_on_quadrature(f, mesh, degree):
+    shape = f.ufl_shape
+    Vge = get_quadrature_element(mesh.ufl_cell(), degree, shape)
+    Vg = FunctionSpace(mesh, Vge)
+    dx = Measure("dx", domain=mesh, metadata={"quadrature_scheme": "default",
+                                              "quadrature_degree": degree})
+    fg = Function(Vg)
+    fg.assign(local_project(f, Vg, dx))
+    return fg
+
+def compute_on_quadrature(f, mesh, degree):
+    shape = f.ufl_shape
+    Vge = get_quadrature_element(mesh.ufl_cell(), degree, shape)
+    Vg = FunctionSpace(mesh, Vge)
+    dx = Measure("dx", domain=mesh, metadata={"quadrature_scheme": "default",
+                                              "quadrature_degree": degree})
+    fg = Function(Vg)
+    if (isinstance(f, function.function.Function) or
+        isinstance(f, function.function.Constant) or
+        isinstance(f, function.function.Expression)):
+        fg.interpolate(f)
+        # return interpolate_on_quadrature(f, degree)
+    else:
+        fg.assign(local_project(f, Vg, dx))
+    return fg
+        # fg.interpolate(f)
+        # return project_on_quadrature(f, degree)


### PR DESCRIPTION
This PR allows the use of defining material rotation from the `FEniCS` side.

* `MFront` behaviours are expressed in the local material frame
* `FEniCS` fields (gradients, fluxes, etc...) are expressed in the global reference frame
* a material rotation matrix is passed upon instantiating the material (it can either be a constant matrix e.g. a `numpy` array or a `FEniCS` object e.g. a Tensor Function or a UFL object of matrix type, expressed using variable angles for instance)
* gradients are rotated from the reference to the material frame before calling the behaviour integration
* fluxes and tangent operator blocks are rotated back from the material to the reference frame after the integration
 
A demo illustrating such features will follow in a separate PR.

This PR also includes some improvements on the definition of spatially variable material properties which can now be any `FEniCS` object which can be interpolated or projected onto a `Quadrature` function space e.g. Constants, Expressions or functions defined on another function space...
