### PR TITLE
dtau_ddF not supported by getRotateArrayOfBehaviourTangentOperatorBlocksFunction

### DIFF
--- a/src/LibrariesManager.cxx
+++ b/src/LibrariesManager.cxx
@@ -548,6 +548,8 @@ namespace mgis {
         return "dsig_dF";
       } else if (t == mgis::behaviour::FiniteStrainBehaviourOptions::DS_DEGL) {
         return "dPK2_degl";
+      } else if (t == mgis::behaviour::FiniteStrainBehaviourOptions::DTAU_DDF) {
+        return "dtau_ddF";
       } else if (t != mgis::behaviour::FiniteStrainBehaviourOptions::DPK1_DF) {
         mgis::raise(
             "LibrariesManager::"


### PR DESCRIPTION
With this behaviour [GdefMonoCrystal.mfront](https://gitlab.com/codeaster/src/-/blob/8bfef15ec1b1dc7685cf96fd7717611f87ab34e4/astest/GdefMonoCrystal.mfront), it fails as:

```python
>>> import mgis.behaviour as mgb
>>> h = mgb.Hypothesis.Tridimensional
>>> o = mgb.FiniteStrainBehaviourOptions()
>>> o.stress_measure = mgb.FiniteStrainBehaviourOptionsStressMeasure.CAUCHY
>>> o.tangent_operator = mgb.FiniteStrainBehaviourOptionsTangentOperator.DTAU_DDF
>>> b = mgb.load(o, "src/libBehaviour.so", "GdefMonoCrystal", h)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: LibrariesManager::getRotateArrayOfBehaviourTangentOperatorBlocksFunction: unsupported tangent operator type                                                                                         
```

