### PR TITLE
rliv-2.0 fix

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,12 +17,12 @@ mgis_library(MFrontGenericInterface
       Model.cxx)
 target_include_directories(MFrontGenericInterface
    PUBLIC 
-   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
    $<INSTALL_INTERFACE:include>)
 if(enable-static)
   target_include_directories(MFrontGenericInterface-static
     PUBLIC 
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>)
 endif(enable-static)
 if(UNIX)


### PR DESCRIPTION
Dear Thomas,

yesterdays change (https://github.com/thelfer/MFrontGenericInterfaceSupport/commit/50e397845a15adccabb271404153dfee7267ea17) broke our builds ([example](https://gitlab.opengeosys.org/ogs/ogs/-/jobs/343445)). This fixes it.

Thanks!