### PR TITLE
Add a new target "make package"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,3 +283,12 @@ if(MGIS_HAVE_TFEL)
   add_subdirectory(tests)
 endif(MGIS_HAVE_TFEL)
 add_subdirectory(bindings)
+
+set(CPACK_SOURCE_GENERATOR "TGZ")
+set(CPACK_SOURCE_IGNORE_FILES
+  \\.git/
+  build/
+  ".*~$"
+)
+set(CPACK_VERBATIM_VARIABLES YES)
+include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,5 +286,5 @@ add_subdirectory(bindings)
 
 set(CPACK_VERBATIM_VARIABLES YES)
 set(CPACK_SOURCE_GENERATOR "TGZ")
-set(CPACK_SOURCE_IGNORE_FILES "build;/\\\\.svn/;.*~")
+set(CPACK_SOURCE_IGNORE_FILES "build;/\\.git/;.*~")
 include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,11 +284,7 @@ if(MGIS_HAVE_TFEL)
 endif(MGIS_HAVE_TFEL)
 add_subdirectory(bindings)
 
-set(CPACK_SOURCE_GENERATOR "TGZ")
-set(CPACK_SOURCE_IGNORE_FILES
-  \\.git/
-  build/
-  ".*~$"
-)
 set(CPACK_VERBATIM_VARIABLES YES)
+set(CPACK_SOURCE_GENERATOR "TGZ")
+set(CPACK_SOURCE_IGNORE_FILES "build;/\\\\.svn/;.*~")
 include(CPack)


### PR DESCRIPTION
Dear Mr. Thomas Helfer,

If this pull request would be merged, you could run the following command in order to build a source package (e.g. to be included in a public docker container).
```
$ make package_source
Run CPack packaging tool for source...
CPack: Create package using TGZ
CPack: Install projects
CPack: - Install directory: ~/install/MFrontGenericInterfaceSupport
CPack: Create package
CPack: - package: ~/install/MFrontGenericInterfaceSupport-build/mfront-generic-interface-0.1.1-Source.tar.gz generated.
```